### PR TITLE
Major bug fix in end functions and smaller fixes in other functions

### DIFF
--- a/UartEvent.h
+++ b/UartEvent.h
@@ -42,11 +42,11 @@
 #include "DMAChannel.h"
 #include "utility/Utils.h"
 ////////////////////////////////////////////////////////////////////////////////
-#define TX0_BUFFER_SIZE 64 // Uart1 outgoing buffer size, must be power of 2  //
-#define RX0_BUFFER_SIZE 64 // Uart1 incoming buffer size, must be power of 2  //
+#define TX0_BUFFER_SIZE 64  // Uart1 outgoing buffer size, must be power of 2 //
+#define RX0_BUFFER_SIZE 64  // Uart1 incoming buffer size, must be power of 2 //
                                                                               //
-#define TX1_BUFFER_SIZE 64 // Uart2 outgoing buffer size, must be power of 2  //
-#define RX1_BUFFER_SIZE 64 // Uart2 incoming buffer size, must be power of 2  //
+#define TX1_BUFFER_SIZE 64  // Uart2 outgoing buffer size, must be power of 2 //
+#define RX1_BUFFER_SIZE 64  // Uart2 incoming buffer size, must be power of 2 //
                                                                               //
 #define TX2_BUFFER_SIZE 128 // Uart3 outgoing buffer size, must be power of 2 //
 #define RX2_BUFFER_SIZE 128 // Uart3 incoming buffer size, must be power of 2 //

--- a/UartEvent.h
+++ b/UartEvent.h
@@ -188,7 +188,7 @@ public:
     }
     virtual void begin( uint32_t baud, uint32_t format ) {
         serial_dma_format( format );
-        serial_dma_begin( BAUD2DIV( baud ) );
+        serial_dma_begin( BAUD2DIV2( baud ) );
     }
     virtual void   begin            ( uint32_t baud )   { serial_dma_begin( BAUD2DIV2( baud ) ); }
     virtual void   end              ( void )            { serial_dma_end( ); }
@@ -274,7 +274,7 @@ public:
     }
     virtual void begin( uint32_t baud, uint32_t format ) {
         serial_dma_format( format );
-        serial_dma_begin( BAUD2DIV( baud ) );
+        serial_dma_begin( BAUD2DIV3( baud ) );
     }
     virtual void   begin            ( uint32_t baud )   { serial_dma_begin( BAUD2DIV3( baud ) ); }
     virtual void   end              ( void )            { serial_dma_end( ); }

--- a/utility/Uart1Event.cpp
+++ b/utility/Uart1Event.cpp
@@ -50,10 +50,12 @@ DMAMEM static volatile BUFTYPE __attribute__((aligned(RX_BUFFER_SIZE))) rx_buffe
 #if TX_BUFFER_SIZE > 255
 static volatile uint16_t tx_buffer_head = 0;
 static volatile uint16_t tx_buffer_tail = 0;
+static volatile bool     tx_buffer_empty = true;
 #else
 #define TX_RETURN_TYPE uint8_t
 static volatile uint8_t tx_buffer_head  = 0;
 static volatile uint8_t tx_buffer_tail  = 0;
+static volatile bool    tx_buffer_empty = true;
 #endif
 #if RX_BUFFER_SIZE > 255
 static volatile uint16_t rx_buffer_head  = 0;
@@ -67,7 +69,6 @@ static volatile uint8_t rx_buffer_count = 0;
 
 static volatile uint8_t transmitting  = 0;
 static volatile uint8_t *transmit_pin = NULL;
-static volatile uint8_t BUFFER_FULL   = false;
 
 DMAChannel        Uart1Event::tx;
 DMAChannel        Uart1Event::rx;
@@ -93,8 +94,10 @@ void Uart1Event::serial_dma_tx_isr( void ) {
     
     if ( ( tail + ELINKNO ) >= TX_BUFFER_SIZE ) tail += ELINKNO - TX_BUFFER_SIZE;
     else tail += ELINKNO;
+
+    if (tail == head) tx_buffer_empty = true;
     
-    if ( head != tail ) {
+    if ( !tx_buffer_empty ) {
         transmitting = true;
         int size;
         if ( tail > head ) size = ( TX_BUFFER_SIZE - tail ) + head;
@@ -246,6 +249,7 @@ void Uart1Event::serial_dma_end( void ) {
     CORE_PIN1_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_MUX( 1 );
     UART0_C5 = UART_DMA_DISABLE;
     tx_buffer_head = tx_buffer_tail = 0;
+    tx_buffer_empty = true;
 }
 
 void Uart1Event::serial_dma_set_transmit_pin( uint8_t pin ) {
@@ -260,6 +264,7 @@ void Uart1Event::serial_dma_putchar( uint32_t c ) {
 }
 
 int Uart1Event::serial_dma_write( const void *buf, unsigned int count ) {
+    if (count == 0) return 0;
     uint8_t * buffer = ( uint8_t * )buf;
     uint32_t head = tx_buffer_head;
     uint32_t cnt = count;
@@ -279,6 +284,7 @@ int Uart1Event::serial_dma_write( const void *buf, unsigned int count ) {
         head += cnt;
     }
     tx_buffer_head = head;
+    tx_buffer_empty = false;
     if ( !transmitting ) {
         transmitting = true;
         __disable_irq( );
@@ -292,13 +298,8 @@ int Uart1Event::serial_dma_write( const void *buf, unsigned int count ) {
 
 void Uart1Event::serial_dma_flush( void ) {
     // wait for any remainding dma transfers to complete
-    uint16_t head, tail;
     //raise_priority( );
-    do {
-        yield( );
-        head = tx_buffer_head;
-        tail = tx_buffer_tail;
-    } while ( head != tail );
+    while ( serial_dma_write_buffer_free() != TX_BUFFER_SIZE ) yield();
     while ( transmitting ) yield( );
     //lower_priority( );
 }
@@ -307,8 +308,9 @@ int Uart1Event::serial_dma_write_buffer_free( void ) {
     uint32_t head, tail;
     head = tx_buffer_head;
     tail = tx_buffer_tail;
-    if ( head >= tail ) return TX_BUFFER_SIZE - 1 - head + tail;
-    return tail - head - 1;
+    if ( (head == tail) && !tx_buffer_empty ) return 0;
+    if ( head >= tail ) return TX_BUFFER_SIZE - head + tail;
+    return tail - head;
 }
 
 int Uart1Event::serial_dma_available( void ) {

--- a/utility/Uart1Event.cpp
+++ b/utility/Uart1Event.cpp
@@ -235,9 +235,9 @@ void Uart1Event::serial_dma_end( void ) {
     if ( !( SIM_SCGC6 & SIM_SCGC6_DMAMUX ) ) return;
     if ( !( SIM_SCGC4 & SIM_SCGC4_UART0 ) ) return;
     attachInterruptVector( IRQ_UART0_STATUS, uart0_status_isr );
+    NVIC_DISABLE_IRQ(IRQ_UART0_STATUS);
     // flush Uart1Event tx buffer
     flush( );
-    delay(20);
     /****************************************************************
      * serial1 end, from teensduino core, serial1.c
      ****************************************************************/

--- a/utility/Uart2Event.cpp
+++ b/utility/Uart2Event.cpp
@@ -233,9 +233,9 @@ void Uart2Event::serial_dma_end( void ) {
     if ( !( SIM_SCGC6 & SIM_SCGC6_DMAMUX ) ) return;
     if ( !( SIM_SCGC4 & SIM_SCGC4_UART1 ) ) return;
     attachInterruptVector( IRQ_UART1_STATUS, uart1_status_isr );
+    NVIC_DISABLE_IRQ(IRQ_UART1_STATUS);
     // flush Uart2Event tx buffer
     flush( );
-    delay(20);
     /****************************************************************
      * serial1 end, from teensduino core, serial1.c
      ****************************************************************/
@@ -273,7 +273,7 @@ int Uart2Event::serial_dma_write( const void *buf, unsigned int count ) {
         head = over;
     }
     else {
-        memcpy_fast( tx_buffer+head, buffer, count );
+        memcpy_fast( tx_buffer+head, buffer, cnt );
         head += cnt;
     }
     tx_buffer_head = head;
@@ -285,6 +285,7 @@ int Uart2Event::serial_dma_write( const void *buf, unsigned int count ) {
         tx.enable( );
         __enable_irq( );
     }
+    return cnt;
 }
 
 void Uart2Event::serial_dma_flush( void ) {

--- a/utility/Uart2Event.cpp
+++ b/utility/Uart2Event.cpp
@@ -50,9 +50,11 @@ DMAMEM static volatile BUFTYPE __attribute__((aligned(RX_BUFFER_SIZE))) rx_buffe
 #if TX_BUFFER_SIZE > 255
 static volatile uint16_t tx_buffer_head = 0;
 static volatile uint16_t tx_buffer_tail = 0;
+static volatile bool     tx_buffer_empty = true;
 #else
 static volatile uint8_t tx_buffer_head  = 0;
 static volatile uint8_t tx_buffer_tail  = 0;
+static volatile bool    tx_buffer_empty = true;
 #endif
 #if RX_BUFFER_SIZE > 255
 static volatile uint16_t rx_buffer_head  = 0;
@@ -66,7 +68,6 @@ static volatile uint8_t rx_buffer_count = 0;
 
 static volatile uint8_t transmitting  = 0;
 static volatile uint8_t *transmit_pin = NULL;
-static volatile uint8_t BUFFER_FULL   = false;
 
 DMAChannel        Uart2Event::tx;
 DMAChannel        Uart2Event::rx;
@@ -92,8 +93,10 @@ void Uart2Event::serial_dma_tx_isr( void ) {
     
     if ( ( tail + ELINKNO ) >= TX_BUFFER_SIZE ) tail += ELINKNO - TX_BUFFER_SIZE;
     else tail += ELINKNO;
+
+    if (tail == head) tx_buffer_empty = true;
     
-    if ( head != tail ) {
+    if ( !tx_buffer_empty ) {
         transmitting = true;
         int size;
         if ( tail > head ) size = ( TX_BUFFER_SIZE - tail ) + head;
@@ -244,6 +247,7 @@ void Uart2Event::serial_dma_end( void ) {
     CORE_PIN10_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_MUX( 1 );
     UART1_C5 = UART_DMA_DISABLE;
     tx_buffer_head = tx_buffer_tail = 0;
+    tx_buffer_empty = true;
 }
 
 void Uart2Event::serial_dma_set_transmit_pin( uint8_t pin ) {
@@ -258,6 +262,7 @@ void Uart2Event::serial_dma_putchar( uint32_t c ) {
 }
 
 int Uart2Event::serial_dma_write( const void *buf, unsigned int count ) {
+    if (count == 0) return 0;
     uint8_t * buffer = ( uint8_t * )buf;
     uint32_t head = tx_buffer_head;
     uint32_t cnt = count;
@@ -277,6 +282,7 @@ int Uart2Event::serial_dma_write( const void *buf, unsigned int count ) {
         head += cnt;
     }
     tx_buffer_head = head;
+    tx_buffer_empty = false;
     if ( !transmitting ) {
         transmitting = true;
         __disable_irq( );
@@ -290,13 +296,8 @@ int Uart2Event::serial_dma_write( const void *buf, unsigned int count ) {
 
 void Uart2Event::serial_dma_flush( void ) {
     // wait for any remainding dma transfers to complete
-    uint16_t head, tail;
     //raise_priority( );
-    do {
-        yield( );
-        head = tx_buffer_head;
-        tail = tx_buffer_tail;
-    } while ( head != tail );
+    while ( serial_dma_write_buffer_free() != TX_BUFFER_SIZE ) yield();
     while ( transmitting ) yield( );
     //lower_priority( );
 }
@@ -305,8 +306,9 @@ int Uart2Event::serial_dma_write_buffer_free( void ) {
     uint32_t head, tail;
     head = tx_buffer_head;
     tail = tx_buffer_tail;
-    if ( head >= tail ) return TX_BUFFER_SIZE - 1 - head + tail;
-    return tail - head - 1;
+    if ( (head == tail) && !tx_buffer_empty ) return 0;
+    if ( head >= tail ) return TX_BUFFER_SIZE - head + tail;
+    return tail - head;
 }
 
 int Uart2Event::serial_dma_available( void ) {

--- a/utility/Uart3Event.cpp
+++ b/utility/Uart3Event.cpp
@@ -233,9 +233,9 @@ void Uart3Event::serial_dma_end( void ) {
     if ( !( SIM_SCGC6 & SIM_SCGC6_DMAMUX ) ) return;
     if ( !( SIM_SCGC4 & SIM_SCGC4_UART2 ) ) return;
     attachInterruptVector( IRQ_UART2_STATUS, uart2_status_isr );
+    NVIC_DISABLE_IRQ(IRQ_UART2_STATUS);
     // flush Uart3Event tx buffer
     flush( );
-    delay(20);
     /****************************************************************
      * serial1 end, from teensduino core, serial1.c
      ****************************************************************/
@@ -273,7 +273,7 @@ int Uart3Event::serial_dma_write( const void *buf, unsigned int count ) {
         head = over;
     }
     else {
-        memcpy_fast( tx_buffer+head, buffer, count );
+        memcpy_fast( tx_buffer+head, buffer, cnt );
         head += cnt;
     }
     tx_buffer_head = head;
@@ -285,6 +285,7 @@ int Uart3Event::serial_dma_write( const void *buf, unsigned int count ) {
         tx.enable( );
         __enable_irq( );
     }
+    return cnt;
 }
 
 void Uart3Event::serial_dma_flush( void ) {


### PR DESCRIPTION
Fixed secondary constructor for uart2 and uart3 (they were using the wrong divisor macros)

Added disabling of status IRQ on the end functions of the three uarts. If the irqs were left on the uart was not able to resume transmitting after after calling the end function and the begin function again.

Removed useless delays on the end functions.

Added return instructions that were missing in the write functions of uart2 and uart3